### PR TITLE
Meter-524  Fix sigar_proc_port_get by updating tcp/udp table calls me…

### DIFF
--- a/src/os/win32/sigar_os.h
+++ b/src/os/win32/sigar_os.h
@@ -407,17 +407,19 @@ typedef DWORD (CALLBACK *iphlpapi_get_udp_table)(PMIB_UDPTABLE,
                                                  PDWORD,
                                                  BOOL);
 
-typedef DWORD (CALLBACK *iphlpapi_get_tcpx_table)(PMIB_TCPEXTABLE *,
+typedef DWORD (CALLBACK *iphlpapi_get_tcpx_table)(PVOID,
+                                                  PDWORD,
                                                   BOOL,
-                                                  HANDLE,
-                                                  DWORD,
-                                                  DWORD);
+                                                  ULONG,
+                                                  TCP_TABLE_CLASS,
+                                                  ULONG);
 
-typedef DWORD (CALLBACK *iphlpapi_get_udpx_table)(PMIB_UDPEXTABLE *,
+typedef DWORD (CALLBACK *iphlpapi_get_udpx_table)(PVOID,
+                                                  PDWORD,
                                                   BOOL,
-                                                  HANDLE,
-                                                  DWORD,
-                                                  DWORD);
+                                                  ULONG,
+                                                  UDP_TABLE_CLASS,
+                                                  ULONG);
 
 typedef DWORD (CALLBACK *iphlpapi_get_tcp_stats)(PMIB_TCPSTATS);
 


### PR DESCRIPTION
Use a non-deprecated call in iphlpapi to pull proc/port connection data.