### PR TITLE
Collect disk I/O in a container under Linux

### DIFF
--- a/src/os/linux/linux_sigar.c
+++ b/src/os/linux/linux_sigar.c
@@ -1245,9 +1245,9 @@ int sigar_file_system_list_get(sigar_t *sigar,
                 }
             }
             closedir(ext_dirp);
-    	}
+        }
         closedir(dirp);
-	} else {
+    } else {
 
         if (!(fp = setmntent(MOUNTED, "r"))) {
             return errno;
@@ -1270,7 +1270,7 @@ int sigar_file_system_list_get(sigar_t *sigar,
         }
 
         endmntent(fp);
-	}
+    }
 
     return SIGAR_OK;
 }


### PR DESCRIPTION
This is tested under Ubuntu.  If we find it doesn't work in a particular linux flavor, we can disable core metrics collection.