### PR TITLE
Hooks for collecting host metrics from a docker container

### DIFF
--- a/include/sigar.h
+++ b/include/sigar.h
@@ -129,6 +129,8 @@ typedef gid_t sigar_gid_t;
 
 typedef struct sigar_t sigar_t;
 
+SIGAR_DECLARE(void) sigar_set_host_fs_prefix(const char *prefix);
+
 SIGAR_DECLARE(int) sigar_open(sigar_t **sigar);
 
 SIGAR_DECLARE(int) sigar_close(sigar_t *sigar);
@@ -1048,6 +1050,8 @@ sigar_rma_get_average(sigar_rma_stat_t * rma,
                       int rate,
                       sigar_int64_t cur_time_sec,
                       int *result);
+
+SIGAR_DECLARE(int) sigar_check_for_container();
 
 #define SIGAR_CONTAINER_MODE_OFF    0 // Force container mode off.
 #define SIGAR_CONTAINER_MODE_ON     1 // Force container mode on.

--- a/include/sigar_util.h
+++ b/include/sigar_util.h
@@ -66,6 +66,13 @@
 #define PROCP_FS_ROOT "/proc/"
 #endif
 
+/*
+ * This is used in the event we want to prefix the standard FS location with
+ * a parent directory.   This is useful, for example, in a docker container.
+ */
+
+extern const char *gHostFSPrefix;
+
 sigar_int64_t sigar_time_now_millis(void);
 
 char *sigar_uitoa(char *buf, unsigned int n, int *len);
@@ -84,6 +91,8 @@ SIGAR_INLINE char *sigar_skip_token(char *p);
 SIGAR_INLINE char *sigar_skip_multiple_token(char *p, int count);
 
 int sigar_skip_file_lines(FILE *fp, int count);
+
+char *sigar_proc_path(char **path, char *prefix, char *suffix);
 
 char *sigar_getword(char **line, char stop);
 

--- a/src/sigar.c
+++ b/src/sigar.c
@@ -45,6 +45,16 @@
 #include "sigar_os.h"
 #include "sigar_format.h"
 
+/*
+ * Set the Host system FS prefix.  If this is used, then it *must* be
+ * done before calling sigar_open
+ */
+
+SIGAR_DECLARE(void) sigar_set_host_fs_prefix(const char *prefix)
+{
+    gHostFSPrefix = prefix;
+}
+
 SIGAR_DECLARE(int) sigar_open(sigar_t **sigar)
 {
     int status = sigar_os_open(sigar);
@@ -2358,6 +2368,11 @@ SIGAR_DECLARE(int) sigar_fqdn_get(sigar_t *sigar, char *name, int namelen)
     }
 
     return SIGAR_OK;
+}
+
+SIGAR_DECLARE(int) sigar_check_for_container()
+{
+    return sigar_os_is_in_container(NULL);
 }
 
 SIGAR_DECLARE(void) sigar_set_container_mode(sigar_t *sigar, int mode)


### PR DESCRIPTION
Tested on various OS's.  
The majority of the work here is setting up a prefix for the system metrics path.
Opt'd for statically allocated variables for the system path for performance.
They are global so any other instance of sigar_open within the same app will pick them up.