### PR TITLE
fix libsigar on linux to return full process names if possible

### DIFF
--- a/src/os/linux/linux_sigar.c
+++ b/src/os/linux/linux_sigar.c
@@ -948,7 +948,22 @@ int sigar_proc_state_get(sigar_t *sigar, sigar_pid_t pid,
         return status;
     }
 
-    memcpy(procstate->name, pstat->name, sizeof(procstate->name));
+    /*
+     * the normal Linux proc name truncates at 15 characters. If we see a 15
+     * character filename, assume it is truncated and attempt to extract the
+     * full name from the process arguments.
+     */
+    memset(procstate->name, 0, sizeof(procstate->name));
+    const char *procname = pstat->name;
+    if (strlen(pstat->name) == 15) {
+        sigar_proc_args_t procargs = { 0 };
+        if (sigar_procfs_args_get(sigar, pid, &procargs) == SIGAR_OK &&
+                procargs.number >= 1) {
+            procname = procargs.data[0];
+        }
+    }
+    strncpy(procstate->name, procname, sizeof(procstate->name) - 1);
+
     procstate->state = pstat->state;
 
     procstate->ppid     = pstat->ppid;


### PR DESCRIPTION
@bwatters-r7 noticed that process listing in Linux truncates the names of all processes > 15 characters. This PR adds a fallback in that case and tries to extract the full process name from the process arguments instead.

This also fixes some fishy-looking memcpy-as-strcpy semantics.