### PR TITLE
tests: Remove unused variable

### DIFF
--- a/tests/t_sigar_version.c
+++ b/tests/t_sigar_version.c
@@ -59,7 +59,6 @@ TEST(test_sigar_version_get) {
 
 int main() {
 	sigar_t *t;
-	int err = 0;
 	
 	assert(SIGAR_OK == sigar_open(&t));
 


### PR DESCRIPTION
This commit removes the unused variable `err` in `t_sigar_version.c`, which permits the tests to be compiled with Clang without setting `-Wno-unused-variable`.