### PR TITLE
optionally build rpc support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,7 +84,7 @@ case $host_os in
 esac
 AC_MSG_RESULT([$SRC_OS])
 
-AC_CHECK_HEADERS(utmp.h utmpx.h libproc.h valgrind/valgrind.h libdlpi.h)
+AC_CHECK_HEADERS(utmp.h utmpx.h libproc.h valgrind/valgrind.h libdlpi.h rpc/rpc.h)
 if test $ac_cv_header_libproc_h = yes; then
         AC_DEFINE(DARWIN_HAS_LIBPROC_H, [1], [sigar named them DARWIN_HAS_... instead of HAVE_])
 fi

--- a/src/sigar.c
+++ b/src/sigar.c
@@ -651,7 +651,7 @@ sigar_file_system_ping(sigar_t *sigar,
                        sigar_file_system_t *fs)
 {
     int status = SIGAR_OK;
-#ifndef WIN32
+#ifdef HAVE_RPC_RPC_H
     char *ptr;
 
     if ((fs->type == SIGAR_FSTYPE_NETWORK) &&

--- a/src/sigar_util.c
+++ b/src/sigar_util.c
@@ -836,7 +836,7 @@ int sigar_cpu_mhz_from_model(char *model)
     return mhz;
 }
 
-#if !defined(WIN32) && !defined(NETWARE)
+#ifdef HAVE_RPC_RPC_H
 #include <netdb.h>
 #include <rpc/rpc.h>
 #include <rpc/pmap_prot.h>


### PR DESCRIPTION
Currently libsigar assumes every OS except for Windows and Netware have Sun RPC support. With recent C libraries (especially embedded systems), this is not true. Instead of assuming, check if rpc.h exists to determine whether to build support.