### PR TITLE
Modernize default config options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,7 +66,7 @@ case $host_os in
      *linux*)
      SRC_OS="linux"
      AC_DEFINE(SIGAR_TEST_OS_LINUX, [1], [for the tests])
-      CFLAGS="$CFLAGS -D_DEFAULT_SOURCE"
+      CFLAGS="$CFLAGS -D_DEFAULT_SOURCE -D_GNU_SOURCE"
      ;;
      *solaris*)
      AC_DEFINE(SOLARIS,[],[running on Solaris])

--- a/configure.ac
+++ b/configure.ac
@@ -26,7 +26,7 @@ AC_CONFIG_MACRO_DIR([m4])
 
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
-CFLAGS="$CFLAGS -Wall -Werror"
+CFLAGS="$CFLAGS -Wall"
 
 AC_MSG_CHECKING([for os type ($host_os)])
 FRAMEWORK=
@@ -66,7 +66,7 @@ case $host_os in
      *linux*)
      SRC_OS="linux"
      AC_DEFINE(SIGAR_TEST_OS_LINUX, [1], [for the tests])
-      CFLAGS="$CFLAGS -D_BSD_SOURCE=1 -D_XOPEN_SOURCE"
+      CFLAGS="$CFLAGS -D_DEFAULT_SOURCE"
      ;;
      *solaris*)
      AC_DEFINE(SOLARIS,[],[running on Solaris])


### PR DESCRIPTION
_BSD_SOURCE is deprecated in glibc > 2.19 and defining _XOPEN_SOURCE without a value doesn't make much sense (it should be 500,600,700,etc.). To get the same effect and features, define _DEFAULT_SOURCE for glibc >= 2.20, and _GNU_SOURCE for the rest.