### PR TITLE
include missing headers

### DIFF
--- a/src/os/linux/linux_sigar.c
+++ b/src/os/linux/linux_sigar.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <linux/param.h>
 #include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/times.h>

--- a/src/sigar_util.c
+++ b/src/sigar_util.c
@@ -32,6 +32,7 @@ const char *gHostFSPrefix = NULL;
 
 #include <dirent.h>
 #include <sys/stat.h>
+#include <sys/time.h>
 
 SIGAR_INLINE char *sigar_uitoa(char *buf, unsigned int n, int *len)
 {


### PR DESCRIPTION
There are a couple of missing headers that happen to work on glibc by accident, but we should include. Specifically this is needed to compile with recent versions of musl libc.