### PR TITLE
conditionally define WbemLocator

### DIFF
--- a/src/os/win32/wmi.cpp
+++ b/src/os/win32/wmi.cpp
@@ -41,7 +41,7 @@
 #define SIGAR_CMDLINE_MAX 4096<<2
 #endif
 
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) && !defined(__WbemLocator_FWD_DEFINED__)
 
 DEFINE_GUID(CLSID_WbemLocator, 0x4590f811, 0x1d3a, 0x11d0, 0x89, 0x1f, 0x00, 0xaa, 0x00, 0x4b, 0x2e, 0x24);
 template <> const GUID & __mingw_uuidof < IWbemLocator > () {
@@ -51,6 +51,7 @@ template <> const GUID & __mingw_uuidof < IWbemLocator > () {
 template <> const GUID & __mingw_uuidof < IWbemLocator * >() {
 	return __mingw_uuidof < IWbemLocator > ();
 }
+
 #endif
 extern "C" {
 


### PR DESCRIPTION
Newer versions of mingw define the missing COM classes for accessing WMI. This fixes a build error with the Mingw compilers that ship with Ubuntu 16.04