### PR TITLE
Use correct Windows PID type size

### DIFF
--- a/include/sigar.h
+++ b/include/sigar.h
@@ -117,9 +117,9 @@ typedef long long sigar_int64_t;
 #endif
 
 #ifdef WIN32
-typedef sigar_uint64_t sigar_pid_t;
-typedef unsigned long sigar_uid_t;
-typedef unsigned long sigar_gid_t;
+typedef sigar_uint32_t sigar_pid_t;
+typedef sigar_uint32_t sigar_uid_t;
+typedef sigar_uint32_t sigar_gid_t;
 #else
 #include <sys/types.h>
 typedef pid_t sigar_pid_t;


### PR DESCRIPTION
Windows PIDs are always a DWORD, which is 32-bit unsigned on all platforms.

UID and GID don't actually make sense on Windows either as an unsigned long (they really should be a character buffer), but as long as we're making things up, and 'unsigned long' is 32-bit on Windows, let's say that explicitly as well.