### PR TITLE
Add missing file to CMake build and allow Win32 XC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-PROJECT(sigar C)
+PROJECT(sigar)
 
 cmake_minimum_required(VERSION 2.6)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,7 +81,7 @@ ENDIF(CMAKE_SYSTEM_NAME MATCHES "(AIX)" )
 
 IF(WIN32)
   ADD_DEFINITIONS(-DSIGAR_SHARED)
-  SET(SIGAR_SRC os/win32/peb.c os/win32/win32_sigar.c)
+  SET(SIGAR_SRC os/win32/peb.c os/win32/win32_sigar.c os/win32/wmi.cpp)
   INCLUDE_DIRECTORIES(os/win32)
   CHECK_STRUCT_MEMBER(MIB_IPADDRROW wType "windows.h;iphlpapi.h" wType_in_MIB_IPADDRROW)
   add_definitions(-DHAVE_MIB_IPADDRROW_WTYPE=${wType_in_MIB_IPADDRROW})
@@ -93,6 +93,7 @@ SET(SIGAR_SRC ${SIGAR_SRC}
   sigar_fileinfo.c
   sigar_format.c
   sigar_ptql.c
+  sigar_rma.c
   sigar_signal.c
   sigar_util.c
 )


### PR DESCRIPTION
sigar_rma.c is missing from the source file list across all platforms, and wmi.cpp is missing from the source file list for Windows. This pull request adds them, and changes the project specification away from pure C as the Win32 build uses C++. This allows correct cross compilation using CMake using mingw-w64 on Ubuntu 16.04 and 14.04 (GCC 5 and 4.x respectively).