### PR TITLE
win32: Do not define strcasecmp if defined

### DIFF
--- a/include/sigar_private.h
+++ b/include/sigar_private.h
@@ -117,8 +117,13 @@
 #endif
 
 #ifdef WIN32
-#define strcasecmp stricmp
-#define strncasecmp strnicmp
+    #ifndef strcasecmp
+    #define strcasecmp stricmp
+    #endif
+
+    #ifndef strncasecmp
+    #define strncasecmp strnicmp
+    #endif
 #endif
 
 #ifndef strcaseEQ


### PR DESCRIPTION
It appears late builds of mingw-w64 already define strcasecmp and
strncasecmp appropriately, leading to errors of the form below when
cross compiling. This commit only redefines them if they have not
previously been defined.

```
In file included from
/vagrant/deps/libsigar/sigar/src/sigar_util.c:25:0:
/vagrant/deps/libsigar/sigar/include/sigar_private.h:120:0: warning:
"strcasecmp" redefined [enabled by default]
 #define strcasecmp stricmp
 ^
In file included from /usr/share/mingw-w64/include/io.h:10:0,
                 from /usr/share/mingw-w64/include/fcntl.h:8,
                 from /vagrant/deps/libsigar/sigar/src/sigar_util.c:21:
/usr/share/mingw-w64/include/string.h:106:0: note: this is the location
of the previous definition
 #define strcasecmp _stricmp
 ^
In file included from
/vagrant/deps/libsigar/sigar/src/sigar_util.c:25:0:
/vagrant/deps/libsigar/sigar/include/sigar_private.h:121:0: warning:
"strncasecmp" redefined [enabled by default]
 #define strncasecmp strnicmp
 ^
In file included from /usr/share/mingw-w64/include/io.h:10:0,
                 from /usr/share/mingw-w64/include/fcntl.h:8,
                 from /vagrant/deps/libsigar/sigar/src/sigar_util.c:21:
/usr/share/mingw-w64/include/string.h:105:0: note: this is the location
of the previous definition
 #define strncasecmp _strnicmp
```