### PR TITLE
Also build static version of libsigar

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,10 @@ SET(SIGAR_SRC ${SIGAR_SRC}
 )
 
 ADD_LIBRARY(sigar SHARED ${SIGAR_SRC})
+
+ADD_LIBRARY(sigar_static STATIC ${SIGAR_SRC})
+set_target_properties(sigar_static PROPERTIES OUTPUT_NAME sigar)
+
 IF(WIN32)
 	TARGET_LINK_LIBRARIES(sigar ws2_32 netapi32 version)
 ENDIF(WIN32)


### PR DESCRIPTION
Added generation of static version of libsigar.

Not sure if this is something you(the repository) wants, but in my usage scenario static linking avoids having to make install the library, requiring sudo/root access.
