### PR TITLE
Add High Sierra and Mojave codenames

### DIFF
--- a/src/os/darwin/darwin_sigar.c
+++ b/src/os/darwin/darwin_sigar.c
@@ -3769,6 +3769,12 @@ int sigar_os_sys_info_get(sigar_t *sigar,
           case 12:
             codename = "Sierra";
             break;
+          case 13:
+            codename = "High Sierra";
+            break;
+          case 14:
+            codename = "Mojave";
+            break;
           default:
             codename = "Unknown";
             break;


### PR DESCRIPTION
This commit adds the codenames for OSX minor versions 13 and 14.